### PR TITLE
docs: prefer latest compatible major when adding packages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,8 @@ Fix any failures and rerun both commands before completing the task.
 
 - Keep all source code in `src/`.
 - Prefer early returns to reduce nesting.
+- When adding a package, choose the latest compatible major, unless there is a specific
+  compatibility reason not to.
 
 ## HTTP requests
 


### PR DESCRIPTION
- Add guidance to prefer the latest compatible major version when
  adding packages to the project.
- Helps maintain consistency and avoid accidental pinning to older
  major versions.
- Documentation-only change; no runtime behavior changes.